### PR TITLE
equality must be case insensitive RFC4343 s. 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,21 +12,24 @@ Can also convert between absolute and relative FQDNs.
 
     from fqdn import FQDN
 
-
     domain = 'bbc.co.uk'
-    fqdn = FQDN(domain)
+    bbc_fqdn = FQDN(domain)
 
-    fqdn.is_valid
+    bbc_fqdn.is_valid
     # True
 
-    fqdn.is_valid_absolute
+    bbc_fqdn.is_valid_absolute
     # False
 
-    fqdn.is_valid_relative
+    bbc_fqdn.is_valid_relative
     # True
 
-    fqdn.absolute
+    bbc_fqdn.absolute
     # bbc.co.uk.
+
+    FQDN("bbc.co.uk") == FQDN("BBC.CO.UK.")
+    # True
+
 
 .. |Build Status| image:: https://travis-ci.org/ypcrts/fqdn.svg?branch=master
    :target: https://travis-ci.org/ypcrts/fqdn?branch=master

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -107,4 +107,4 @@ class FQDN:
 
     def __eq__(self, other):
         if isinstance(other, FQDN):
-            return self.absolute == other.absolute
+            return self.absolute.lower() == other.absolute.lower()

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -150,3 +150,6 @@ class TestEquality(TestCase):
 
     def test_mismatch_are_equal(self):
         self.assertEqual(FQDN("trainwreck.com."), FQDN("trainwreck.com"))
+
+    def test_equality_is_case_insensitive(self):
+        self.assertEqual(FQDN("all-letters-were-created-equal.com."), FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM."))

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -152,4 +152,7 @@ class TestEquality(TestCase):
         self.assertEqual(FQDN("trainwreck.com."), FQDN("trainwreck.com"))
 
     def test_equality_is_case_insensitive(self):
-        self.assertEqual(FQDN("all-letters-were-created-equal.com."), FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM."))
+        self.assertEqual(
+            FQDN("all-letters-were-created-equal.com."),
+            FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM."),
+        )


### PR DESCRIPTION
[RFC4343 s. 3](https://tools.ietf.org/html/rfc4343)
```
   According to the original DNS design decision, comparisons on name
   lookup for DNS queries should be case insensitive [STD13].  That is
   to say, a lookup string octet with a value in the inclusive range
   from 0x41 to 0x5A, the uppercase ASCII letters, MUST match the
   identical value and also match the corresponding value in the
   inclusive range from 0x61 to 0x7A, the lowercase ASCII letters.
```

@wakemaster39 The equality implementation did not account for case insensitivity, only absolute vs relative. This adds that. Would you have any input?