### PR TITLE
feat: hashable FQDN with locked down FQDN variable

### DIFF
--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -34,10 +34,14 @@ class FQDN:
     def __init__(self, fqdn):
         if not (fqdn and isinstance(fqdn, str)):
             raise ValueError("fqdn must be str")
-        self.fqdn = fqdn
+        self._fqdn = fqdn
 
     def __str__(self):
-        return self.fqdn
+        return self._fqdn
+
+    @property
+    def fqdn(self):
+        return self._fqdn
 
     @cached_property
     def is_valid(self):
@@ -53,12 +57,12 @@ class FQDN:
         trailing null byte), it may have a total length of 254 bytes, still it
         must be less than 253 bytes.
         """
-        length = len(self.fqdn)
-        if self.fqdn.endswith("."):
+        length = len(self._fqdn)
+        if self._fqdn.endswith("."):
             length -= 1
         if length > 253:
             return False
-        return bool(self.FQDN_REGEX.match(self.fqdn))
+        return bool(self.FQDN_REGEX.match(self._fqdn))
 
     @cached_property
     def is_valid_absolute(self):
@@ -69,7 +73,7 @@ class FQDN:
         With relative FQDNS in DNS lookups, the current hosts domain name or
         search domains may be appended.
         """
-        return self.fqdn.endswith(".") and self.is_valid
+        return self._fqdn.endswith(".") and self.is_valid
 
     @cached_property
     def is_valid_relative(self):
@@ -77,7 +81,7 @@ class FQDN:
         True for a validated fully-qualified domain name that compiles with the
         RFC preferred-form and does not ends with a `.`.
         """
-        return not self.fqdn.endswith(".") and self.is_valid
+        return not self._fqdn.endswith(".") and self.is_valid
 
     @cached_property
     def absolute(self):
@@ -85,12 +89,12 @@ class FQDN:
         The FQDN as a string in absolute form
         """
         if not self.is_valid:
-            raise ValueError("invalid FQDN `{0}`".format(self.fqdn))
+            raise ValueError("invalid FQDN `{0}`".format(self._fqdn))
 
         if self.is_valid_absolute:
-            return self.fqdn
+            return self._fqdn
 
-        return "{0}.".format(self.fqdn)
+        return "{0}.".format(self._fqdn)
 
     @cached_property
     def relative(self):
@@ -98,13 +102,16 @@ class FQDN:
         The FQDN as a string in relative form
         """
         if not self.is_valid:
-            raise ValueError("invalid FQDN `{0}`".format(self.fqdn))
+            raise ValueError("invalid FQDN `{0}`".format(self._fqdn))
 
         if self.is_valid_absolute:
-            return self.fqdn[:-1]
+            return self._fqdn[:-1]
 
-        return self.fqdn
+        return self._fqdn
 
     def __eq__(self, other):
         if isinstance(other, FQDN):
             return self.absolute.lower() == other.absolute.lower()
+
+    def __hash__(self):
+        return hash(self.absolute)

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -114,4 +114,4 @@ class FQDN:
             return self.absolute.lower() == other.absolute.lower()
 
     def __hash__(self):
-        return hash(self.absolute)
+        return hash(self.absolute.lower()) + hash("fqdn")

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -39,10 +39,6 @@ class FQDN:
     def __str__(self):
         return self._fqdn
 
-    @property
-    def fqdn(self):
-        return self._fqdn
-
     @cached_property
     def is_valid(self):
         """

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -156,3 +156,24 @@ class TestEquality(TestCase):
             FQDN("all-letters-were-created-equal.com."),
             FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM."),
         )
+
+class TestHash(TestCase):
+    def test_is_hashable(self):
+        self.assertTrue(hash(FQDN("trainwreck.com.")))
+    def test_absolutes_are_equal(self):
+        self.assertEqual(hash(FQDN("trainwreck.com.")), hash(FQDN("trainwreck.com.")))
+
+    def test_relatives_are_equal(self):
+        self.assertEqual(hash(FQDN("trainwreck.com")), hash(FQDN("trainwreck.com")))
+
+    def test_mismatch_are_equal(self):
+        self.assertEqual(hash(FQDN("trainwreck.com.")), hash(FQDN("trainwreck.com")))
+
+    def test_equality_is_case_insensitive(self):
+        self.assertEqual(
+            hash(FQDN("all-letters-were-created-equal.com.")),
+            hash(FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM.")),
+        )
+
+    def test_not_equal_to_string(self):
+        self.assertNotEqual(hash(FQDN("trainwreck.com.")), hash("trainwreck.com."))

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -177,3 +177,7 @@ class TestHash(TestCase):
 
     def test_not_equal_to_string(self):
         self.assertNotEqual(hash(FQDN("trainwreck.com.")), hash("trainwreck.com."))
+
+    def test_different_fqdns_are_not_equal(self):
+        self.assertNotEqual(hash(FQDN("trainwreck.com.")), hash(FQDN("test.com.")))
+

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -157,9 +157,11 @@ class TestEquality(TestCase):
             FQDN("ALL-LETTERS-WERE-CREATED-EQUAL.COM."),
         )
 
+
 class TestHash(TestCase):
     def test_is_hashable(self):
         self.assertTrue(hash(FQDN("trainwreck.com.")))
+
     def test_absolutes_are_equal(self):
         self.assertEqual(hash(FQDN("trainwreck.com.")), hash(FQDN("trainwreck.com.")))
 
@@ -180,4 +182,3 @@ class TestHash(TestCase):
 
     def test_different_fqdns_are_not_equal(self):
         self.assertNotEqual(hash(FQDN("trainwreck.com.")), hash(FQDN("test.com.")))
-


### PR DESCRIPTION
Since absolute and things are wrapped in `@cached_properties`, changing `self.fqdn` out from underneath it is really bad. Hide this away and expose a fqdn property in case someone was actually using this field for anything.

Since we have defined equality, and we are protecting `_fqdn` kind of now might as well define hashable as well so they can be dictionary keys or anything else. Hashable is based on absolute just like equality, which feels weird now having the `@fqdn` property being different. I would kill it personally but that would require a roll to version 2.0.

Stopped short of messing with `set_attr` or slots to ensure immutable.  