### PR TITLE
Remove cached_property dependency for python 3.8

### DIFF
--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -2,6 +2,7 @@ import re
 
 from fqdn._compat import cached_property
 
+
 class FQDN:
     """
     From https://tools.ietf.org/html/rfc1035#page-9,  RFC 1035 3.1. Name space

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -1,7 +1,6 @@
 import re
 
-from cached_property import cached_property
-
+from fqdn._compat import cached_property
 
 class FQDN:
     """

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -36,7 +36,7 @@ class FQDN:
         self._fqdn = fqdn.lower()
 
     def __str__(self):
-        return self._fqdn
+        return self.absolute
 
     @cached_property
     def is_valid(self):

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -33,7 +33,7 @@ class FQDN:
     def __init__(self, fqdn):
         if not (fqdn and isinstance(fqdn, str)):
             raise ValueError("fqdn must be str")
-        self._fqdn = fqdn
+        self._fqdn = fqdn.lower()
 
     def __str__(self):
         return self._fqdn
@@ -106,7 +106,7 @@ class FQDN:
 
     def __eq__(self, other):
         if isinstance(other, FQDN):
-            return self.absolute.lower() == other.absolute.lower()
+            return self.absolute == other.absolute
 
     def __hash__(self):
-        return hash(self.absolute.lower()) + hash("fqdn")
+        return hash(self.absolute) + hash("fqdn")

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -37,7 +37,7 @@ class FQDN:
         self._fqdn = fqdn.lower()
 
     def __str__(self):
-        return self.absolute
+        return self.relative
 
     @cached_property
     def is_valid(self):

--- a/fqdn/_compat.py
+++ b/fqdn/_compat.py
@@ -1,6 +1,5 @@
 import sys
 
-print(sys.version_info[:2])
 if sys.version_info[:2] >= (3, 8):
     from functools import cached_property
 else:

--- a/fqdn/_compat.py
+++ b/fqdn/_compat.py
@@ -1,0 +1,7 @@
+import sys
+
+print(sys.version_info[:2])
+if sys.version_info[:2] >= (3, 8):
+    from functools import cached_property
+else:
+    from cached_property import cached_property

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     keywords=["fqdn", "domain", "hostname", "RFC3686", "dns"],
     license="MPL 2.0",
     zip_safe=True,
-    install_requires=["cached-property>=1.3.0"],
+    install_requires=["cached-property>=1.3.0;python_version<'3.8'"],
     test_suite="tests",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -21,9 +21,8 @@ class TestFQDNValidation(TestCase):
 
     def test_str(self):
         d = "greatdomain.com"
-        assert d + "." == str(FQDN(d))
-        d += "."
         assert d == str(FQDN(d))
+        assert d == str(FQDN(d + "."))
 
     def test_rfc_1035_s_2_3_4__label_max_length(self):
         self.__assert_valid(

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -21,7 +21,7 @@ class TestFQDNValidation(TestCase):
 
     def test_str(self):
         d = "greatdomain.com"
-        assert d == str(FQDN(d))
+        assert d + "." == str(FQDN(d))
         d += "."
         assert d == str(FQDN(d))
 


### PR DESCRIPTION
Currently not using any of the added stuff from cached_property inside of the class. Use the builtin from functools if python 3.8 or newer.

Took first step in punycode by ensuring FQDN is lowered on consturction.