### PR TITLE
Add label matching according to RFC 1123

### DIFF
--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -143,3 +143,38 @@ class FQDN:
 
     def __hash__(self):
         return hash(self.absolute) + hash("fqdn")
+
+
+class Label:
+    """
+    A RFC 1123 label must consist of alphanumeric characters
+    or '-', and must start and end with an alphanumeric character
+    for example 'my-name',  or '123-abc'
+    """
+
+    RFC_1123_LABLE_REGEX = r"[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+
+    def __init__(self, label, *nothing, **kwargs):
+        if nothing:
+            raise ValueError("got extra positional parameter, try kwargs")
+        unknown_kwargs = set(kwargs.keys()) - {"label"}
+        if unknown_kwargs:
+            raise ValueError("got extra kwargs: {}".format(unknown_kwargs))
+
+        if not (label and isinstance(label, str) or not label):
+            raise ValueError("label must be str")
+
+        self._label = label.lower()
+
+    @property
+    def _regex(self):
+        return re.compile(self.RFC_1123_LABLE_REGEX)
+
+    @cached_property
+    def is_valid(self):
+        if len(self._label) == 0 or len(self._label) > 63:
+            return False
+        regex_pass = self._regex.match(self._label)
+        if not regex_pass:
+            return False
+        return True

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -152,7 +152,7 @@ class Label:
     for example 'my-name',  or '123-abc'
     """
 
-    RFC_1123_LABLE_REGEX = r"[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+    RFC_1123_LABEL_REGEX = r"[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
 
     def __init__(self, label, *nothing, **kwargs):
         if nothing:

--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -168,7 +168,7 @@ class Label:
 
     @property
     def _regex(self):
-        return re.compile(self.RFC_1123_LABLE_REGEX)
+        return re.compile(self.RFC_1123_LABEL_REGEX)
 
     @cached_property
     def is_valid(self):

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -2,7 +2,7 @@
 import sys
 
 import pytest
-from fqdn import FQDN
+from fqdn import FQDN, Label
 
 
 @pytest.fixture(params=(True, False))
@@ -287,3 +287,44 @@ class TestHash:
         assert hash(FQDN("trainwreck.com.", allow_underscores=False)) == hash(
             FQDN("trainwreck.com", allow_underscores=True)
         )
+
+
+class TestLabel:
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "test-name",
+            "01010",
+            "abc",
+            "a0c",
+            "a-0c",
+            "a",
+            "0-0",
+            "0--0",
+            "A0c",
+            "A-0c",
+            "012345670123456701234567012345670123456701234567012345670123456",
+        ],
+    )
+    def test_valid_labels(self, label):
+        assert Label(label).is_valid
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "0123456701234567012345670123456701234567012345670123456701234567",
+            "o1234567.01234567",
+            "",
+            "   ",
+            "ab cd",
+            "ab..cd",
+            "ab\ncd",
+            "-A0c",
+            "abcd1.",
+            "abcd1-",
+            "ab cd",
+        ],
+    )
+    def test_invalid_labels(self, label):
+        assert not Label(label).is_valid
+        pass


### PR DESCRIPTION
This feature could be helpful to check the __RFC 1123 Label__ standard.

One of the major use-cases is checking strings to be valid for `Kubernetes Namespace`.

Thanks for your attention. I hope it will be helpful for you folks.