### PR TITLE
Accept empty string on construction

### DIFF
--- a/fqdn/__init__.py
+++ b/fqdn/__init__.py
@@ -40,7 +40,7 @@ class FQDN:
         if unknown_kwargs:
             raise ValueError("got extra kwargs: {}".format(unknown_kwargs))
 
-        if not (fqdn and isinstance(fqdn, str)):
+        if not isinstance(fqdn, str):
             raise ValueError("fqdn must be str")
         self._fqdn = fqdn.lower()
         self._allow_underscores = kwargs.get("allow_underscores", False)

--- a/tests/test_fqdn.py
+++ b/tests/test_fqdn.py
@@ -30,6 +30,11 @@ class TestFQDNValidation:
         f = FQDN(d, allow_underscores=a_u)
         assert f.absolute == str(f)
 
+    def test_empty(self, a_u):
+        d = ""
+        f = FQDN(d, allow_underscores=a_u)
+        assert not f.is_valid
+
     def test_rfc_1035_s_2_3_4__label_max_length(self, a_u):
         assert FQDN(
             "www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
@@ -159,8 +164,7 @@ class TestMinLabels:
         assert not dn.is_valid
 
     def test_min_labels_valid_set_to_1(self):
-        with pytest.raises(ValueError):
-            FQDN("", min_labels=1).is_valid
+        assert not FQDN("", min_labels=1).is_valid
         assert FQDN("label", min_labels=1).is_valid
         assert not FQDN(".label", min_labels=1).is_valid
         assert FQDN("label.babel", min_labels=1).is_valid


### PR DESCRIPTION
The empty string is already treated as invalid by the supplied validators. It was incorrect to raise ValueError on construction since this requires users to pre-validate strings before passing to a validation library.

Fixes #45